### PR TITLE
Add record generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ Strings
 JavaScript Objects: boolean, number, string, array of `json` values or object with `json` values.
 
 
+#### record (spec : {a: generator...}) : generator (record {a: generator...})
+
+Generates a javascript object with given record spec.
+
 
 #### array (gen : generator a) : generator (array a)
 

--- a/lib/composite.js
+++ b/lib/composite.js
@@ -88,8 +88,34 @@ function map(gen) {
   };
 }
 
+/**
+  #### record (spec : {a: generator...}) : generator (record {a: generator...})
+
+  Generates a javascript object with given record spec.
+*/
+function record(spec) {
+  return {
+    arbitrary: function (size) {
+      var res = {};
+      Object.keys(spec).forEach(function (k) {
+        var gen = generator.force(spec[k]);
+        res[k] = gen.arbitrary(size);
+      });
+      return res;
+    },
+    shrink: shrink.noop,
+    show: function (m) {
+      return "{" + Object.keys(m).map(function (k) {
+        var gen = generator.force(spec[k]);
+        return k + ": " + gen.show(m[k]);
+      }).join(", ") + "}";
+    }
+  };
+}
+
 module.exports = {
   pair: pair,
   array: array,
   map: map,
+  record: record,
 };

--- a/lib/jsverify.js
+++ b/lib/jsverify.js
@@ -314,6 +314,7 @@ var jsc = {
   pair: composite.pair,
   array: composite.array,
   map: composite.map,
+  record: composite.record,
   fn: fn.fn,
   fun: fn.fn,
   suchthat: combinator.suchthat,

--- a/test/generators.js
+++ b/test/generators.js
@@ -184,4 +184,21 @@ describe("primitive generators", function () {
       }));
     });
   });
+
+  describe("record", function () {
+    var spec = {
+      a: jsc.string,
+      b: jsc.nat,
+      c: jsc.fn
+    };
+
+    it("generates objects according to the spec", function () {
+      jsc.assert(jsc.forall(jsc.record(spec), function (obj) {
+        return _.isObject(obj) &&
+               _.isString(obj.a) &&
+               _.isNumber(obj.b) &&
+               _.isFunction(obj.c);
+      }));
+    });
+  });
 });

--- a/test/shrink.js
+++ b/test/shrink.js
@@ -154,6 +154,21 @@ describe("shrink", function () {
     });
   });
 
+  describe("record", function () {
+    it("cannot be shrinked", function () {
+      var property = jsc.forall(jsc.record({a: jsc.fn()}), function (x) {
+        return x !== x;
+      });
+
+      // try many times to get more examples
+      for (var i = 0; i < 10; i++) {
+        var r = jsc.check(property, { quiet: true });
+        assert(r !== true);
+        assert(r.shrinks === 0);
+      }
+    });
+  });
+
   describe("recursive definitions", function () {
     // TODO: jsverify doesn't find minimal 1, 1 case in recursive setting
     // this "monadic" bind is hard


### PR DESCRIPTION
Generates objects according to a record spec.

``` js
var gen = jsc.record({
  a: jsc.nat,
  b: jsc.string
});
```
