### PR TITLE
Replaces falsy check with `undefined` check in `maxsize` param

### DIFF
--- a/dist/jsverify.standalone.js
+++ b/dist/jsverify.standalone.js
@@ -1585,7 +1585,7 @@ function numeric(impl) {
 var integer = numeric(function integer(maxsize) {
   return {
     generator: generator.bless(function (size) {
-      size = maxsize || size;
+      size = typeof maxsize !== "undefined" ? maxsize : size;
       return random(-size, size);
     }),
     shrink: shrink.bless(function (i) {
@@ -1623,7 +1623,7 @@ extendWithDefault(integer);
 function nat(maxsize) {
   return arbitraryBless({
     generator: generator.bless(function (size) {
-      size = maxsize || size;
+      size = typeof maxsize !== "undefined" ? maxsize : size;
       return random(0, size);
     }),
     shrink: shrink.bless(function (i) {
@@ -1655,7 +1655,7 @@ extendWithDefault(nat);
 var number = numeric(function number(maxsize) {
   return {
     generator: generator.bless(function (size) {
-      size = maxsize || size;
+      size = typeof maxsize !== "undefined" ? maxsize : size;
       return random.number(-size, size);
     }),
     shrink: shrink.bless(function (x) {

--- a/lib/primitive.js
+++ b/lib/primitive.js
@@ -51,7 +51,7 @@ function numeric(impl) {
 var integer = numeric(function integer(maxsize) {
   return {
     generator: generator.bless(function (size) {
-      size = maxsize || size;
+      size = typeof maxsize !== "undefined" ? maxsize : size;
       return random(-size, size);
     }),
     shrink: shrink.bless(function (i) {
@@ -89,7 +89,7 @@ extendWithDefault(integer);
 function nat(maxsize) {
   return arbitraryBless({
     generator: generator.bless(function (size) {
-      size = maxsize || size;
+      size = typeof maxsize !== "undefined" ? maxsize : size;
       return random(0, size);
     }),
     shrink: shrink.bless(function (i) {
@@ -121,7 +121,7 @@ extendWithDefault(nat);
 var number = numeric(function number(maxsize) {
   return {
     generator: generator.bless(function (size) {
-      size = maxsize || size;
+      size = typeof maxsize !== "undefined" ? maxsize : size;
       return random.number(-size, size);
     }),
     shrink: shrink.bless(function (x) {

--- a/test/arbitrary.js
+++ b/test/arbitrary.js
@@ -52,9 +52,21 @@ describe("primitive arbitraries", function () {
       }));
     });
 
+    it("with maxsize == 0, generates integers: abs(_) ≤  maxsize", function () {
+      jsc.assert(jsc.forall(jsc.integer(0), function (i) {
+        return Math.round(i) === i && Math.abs(i) <= 0;
+      }));
+    });
+
     it("with min & max, generates integers: min ≤ _ ≤ max", function () {
       jsc.assert(jsc.forall(jsc.integer(2, 5), function (i) {
         return Math.round(i) === i && i >= 2 && i <= 5;
+      }));
+    });
+
+    it("with min == 0 & max, generates integers: min ≤ _ ≤ max", function () {
+      jsc.assert(jsc.forall(jsc.integer(0, 5), function (i) {
+        return Math.round(i) === i && i >= 0 && i <= 5;
       }));
     });
   });
@@ -63,6 +75,18 @@ describe("primitive arbitraries", function () {
     it("generates non-negative integers", function () {
       jsc.assert(jsc.forall(jsc.nat(), function (n) {
         return Math.round(n) === n && n >= 0;
+      }));
+    });
+
+    it("with maxsize, generates numbers: _ <= maxsize", function () {
+      jsc.assert(jsc.forall(jsc.nat(5), function (i) {
+        return typeof i === "number" && Math.abs(i) <= 5;
+      }));
+    });
+
+    it("with maxsize == 0, generates numbers: _ == maxsize", function () {
+      jsc.assert(jsc.forall(jsc.nat(0), function (i) {
+        return typeof i === "number" && Math.abs(i) === 0;
       }));
     });
   });
@@ -92,9 +116,21 @@ describe("primitive arbitraries", function () {
       }));
     });
 
+    it("with maxsize == 0, generates numbers: abs(_) == maxsize", function () {
+      jsc.assert(jsc.forall(jsc.number(0), function (i) {
+        return typeof i === "number" && Math.abs(i) === 0;
+      }));
+    });
+
     it("with min & max, generates numbers: min ≤ _ < max", function () {
       jsc.assert(jsc.forall(jsc.number(2.2, 5.5), function (i) {
         return typeof i === "number" && i >= 2.2 && i < 5.5;
+      }));
+    });
+
+    it("with min == 0 & max, generates numbers: min ≤ _ < max", function () {
+      jsc.assert(jsc.forall(jsc.number(0, 5.5), function (i) {
+        return typeof i === "number" && i >= 0 && i < 5.5;
       }));
     });
   });


### PR DESCRIPTION
This fixes an issue where `maxsize` is ignored if its value is `0`.