### PR TITLE
Rethrow thrown errors in checkThrow

### DIFF
--- a/lib/jsverify.js
+++ b/lib/jsverify.js
@@ -209,7 +209,7 @@ function forall() {
             return shrinkResult(gens, x, test, size, shrinks, exc, function (rr) {
               return {
                 counterexample: rr.counterexample.concat(rRecPrime.counterexample),
-                counterexamplestr: rr.counterexamplestr ,// + "; " + rRec.counterexamplestr,
+                counterexamplestr: rr.counterexamplestr, // + "; " + rRec.counterexamplestr,
                 shrinks: rr.shrinks,
                 exc: rr.exc || rRecPrime.exc,
               };

--- a/lib/jsverify.js
+++ b/lib/jsverify.js
@@ -229,14 +229,16 @@ function forall() {
   };
 }
 
-function formatFailedCase(r, state) {
+function formatFailedCase(r, state, includeStack) {
   var msg = "Failed after " + r.tests + " tests and " + r.shrinks + " shrinks. ";
   msg += "rngState: " + (r.rngState || state) + "; ";
   msg += "Counterexample: " + r.counterexamplestr + "; ";
   if (r.exc) {
     if (r.exc instanceof Error) {
       msg += "Exception: " + r.exc.message;
-      msg += "\nStack trace: " + r.exc.stack;
+      if (includeStack) {
+        msg += "\nStack trace: " + r.exc.stack;
+      }
     } else {
       msg += "Error: " + r.exc;
     }
@@ -307,7 +309,7 @@ function check(property, opts) {
         rPrime.tests = i;
         /* global console */
         if (!opts.quiet) {
-          console.error(formatFailedCase(rPrime, state), rPrime.counterexample);
+          console.error(formatFailedCase(rPrime, state, true), rPrime.counterexample);
         }
         return rPrime;
       }
@@ -338,7 +340,12 @@ function checkThrow(property, opts) {
 
   return functor.run(functor.map(check(property, opts), function (r) {
     if (r !== true) {
-      throw new Error(formatFailedCase(r));
+      if (r.exc instanceof Error) {
+        r.exc.message = formatFailedCase(r);
+        throw r.exc;
+      } else {
+        throw new Error(formatFailedCase(r));
+      }
     }
   }));
 }

--- a/test/nonquiet.js
+++ b/test/nonquiet.js
@@ -48,4 +48,19 @@ describe("nonquiet cases", function () {
       jsc.check(jsc.forall(jsc.nat(), 1));
     });
   });
+
+  it("assert rethrows exceptions thrown", function () {
+    assert.throws(function () {
+      jsc.assert(jsc.forall(jsc.nat(), function () {
+        var e = new Error();
+        e.stack = "xyzzy";
+        e.extraData = 42;
+        throw e;
+      }), { quiet: true });
+    }, function (e) {
+      return e.message.indexOf("rngState") >= 0 &&
+             e.stack === "xyzzy" &&
+             e.extraData === 42;
+    });
+  });
 });


### PR DESCRIPTION
When checkThrow is called with a property that fails due to a thrown
Error, instead of throwing a new Error whose message includes the stack
trace (which leads to noisy reporting from test frameworks that print
the message), just update the message on the thrown Error and reuse it.
This way, the outer framework has the choice of including the stack
trace or not, and any additional data attached to the Error aren't lost.