### PR TITLE
Changed example boolean arbitraries to jsc.bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ See [perldoc for bless](http://perldoc.perl.org/functions/bless.html).
 There is a small DSL to help with `forall`. For example the two definitions below are equivalent:
 ```js
 var bool_fn_applied_thrice = jsc.forall("bool -> bool", "bool", check);
-var bool_fn_applied_thrice = jsc.forall(jsc.fn(jsc.bool()), jsc.bool(), check);
+var bool_fn_applied_thrice = jsc.forall(jsc.fn(jsc.bool), jsc.bool, check);
 ```
 
 The DSL is based on a subset of language recognized by [typify-parser](https://github.com/phadej/typify-parser):


### PR DESCRIPTION
Writing some tests myself I was blocked on an error coming back saying `TypeError: jsc.bool is not a function`. After some trial and error I found out that the expected syntax is to use `jsc.bool` instead of calling bool as if it is a function as in `jsc.bool()`.