### PR TITLE
Allow specifying options on command line

### DIFF
--- a/lib/jsverify.js
+++ b/lib/jsverify.js
@@ -66,6 +66,12 @@
 
   Errorneous case is found with first try.
 
+  You can provide the following command line arguments to adjust test parameters:
+
+  * `--jsverifyOptsTests 1000`: sets the number of tests to run to 1000
+  * `--jsverifyOptsSize 1000`: sets the maximum size of generated objects to 1000
+  * `--jsverifyOptsQuiet true`: turns off `console.log`
+
   ### Usage with [jasmine](http://pivotal.github.io/jasmine/)
 
   Check [jasmineHelpers.js](helpers/jasmineHelpers.js) and [jasmineHelpers2.js](helpers/jasmineHelpers2.js) for jasmine 1.3 and 2.0 respectively.
@@ -254,6 +260,14 @@ function findRngState(argv) { // eslint-disable-line consistent-return
   }
 }
 
+function findOpts(opt, argv) { // eslint-disable-line consistent-return
+  for (var i = 0; i < argv.length - 1; i++) {
+    if (argv[i] === "--jsverifyOpts" + opt) {
+      return argv[i + 1];
+    }
+  }
+}
+
 /**
   - `check (prop: property, opts: checkoptions?): result`
 
@@ -289,6 +303,12 @@ function check(property, opts) {
     if (argvState) {
       random.setStateString(argvState);
     }
+  }
+
+  if (typeof process !== "undefined") {
+    opts.size = parseInt(findOpts("Size", process.argv), 10) || opts.size;
+    opts.tests = parseInt(findOpts("Tests", process.argv), 10) || opts.tests;
+    opts.quiet = findOpts("Quiet", process.argv) === "true" || opts.quiet;
   }
 
   function loop(i) {


### PR DESCRIPTION
Running `make test` failed at istanbul. I'm not familiar with istanbul so I'm unsure what the best way is to proceed with fixing that error. I'm very much open to suggestions on that.