### PR TITLE
addresses #156 treating NaN equal to itself

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,8 @@
 /* @flow weak */
 "use strict";
 
+var _ = require("lodash");
+
 var isArray = Array.isArray;
 function isObject(o) {
   /* eslint-disable no-new-object */
@@ -31,6 +33,10 @@ function sort(arr) {
 */
 function isEqual(a, b) {
   var i;
+
+  if (_.isNaN(a) && _.isNaN(b)) {
+    return true;
+  }
 
   if (a === b) {
     return true;
@@ -64,6 +70,7 @@ function isEqual(a, b) {
 
       Tests whether two objects are approximately and optimistically equal.
       Returns `false` only if they are distinguisable not equal.
+      Returns `true` when `x` and `y` are `NaN`.
       This function works with cyclic data.
 
       Takes optional 'opts' parameter with properties:
@@ -80,6 +87,10 @@ function isApproxEqual(x, y, opts) {
   var state = [];
 
   function loop(a, b, n) {
+    if (_.isNaN(a) && _.isNaN(b)) {
+      return true;
+    }
+
     // trivial check
     if (a === b) {
       return true;

--- a/test/utility.js
+++ b/test/utility.js
@@ -32,6 +32,10 @@ describe("utility functions: _", function () {
         return jsc.utils.isEqual(x, x);
       }));
     });
+
+    it("considers NaN as equal to itself", function () {
+      assert(jsc.utils.isEqual(NaN, NaN));
+    });
   });
 
   describe("FMap", function () {

--- a/test/utils.js
+++ b/test/utils.js
@@ -81,5 +81,9 @@ describe("jsc.utils", function () {
       return jsc.utils.isApproxEqual({ a: 1, b: 2 }, { a: 2, b: 2 }) === false &&
         jsc.utils.isApproxEqual({ a: 1, b: 2 }, { a: 1, b: 1 }) === false;
     });
+
+    jsc.property("considers NaN as equal to itself", function () {
+      return jsc.utils.isApproxEqual(NaN, NaN);
+    });
   });
 });


### PR DESCRIPTION
I decided to change `utils.isEqual` because it's the function used in `FMap` to see if a key already exists in the underlying `data` array.

To add to that I think that [this test](https://github.com/jsverify/jsverify/blob/master/test/utility.js#L17) hints towards the fact that we want to preserve consistency between how underscore treats values on an `isEqual` check and how `utils.isEqual` treats them.

Before this change the following would return `undefined`

```javascript
var jsc = require("./lib/jsverify");
var result = jsc.sampler(jsc.fn(jsc.number))()(NaN);
console.log(result);
```
while now returns a number.

Finally, I've used `_.isNaN` instead of `isNaN` because the latter was failing on some edge cases (which jsverify spotted :D), like `isNaN([{}])` which returns `true`.

Please feel free to correct / hint towards a better way of solving this, I'm open to reconsidering this.

As an aside, would you consider a PR removing underscore in favour of lodash?