### PR TITLE
Remove implicit lodash dependency from utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,13 +1,16 @@
 /* @flow weak */
 "use strict";
 
-var _ = require("lodash");
-
 var isArray = Array.isArray;
 function isObject(o) {
   /* eslint-disable no-new-object */
   return new Object(o) === o;
   /* eslint-enable no-new-object */
+}
+
+/* undefined-safe isNaN */
+function isNaN(n) {
+  return typeof n === "number" && n !== n;
 }
 
 /**
@@ -34,7 +37,7 @@ function sort(arr) {
 function isEqual(a, b) {
   var i;
 
-  if (_.isNaN(a) && _.isNaN(b)) {
+  if (isNaN(a) && isNaN(b)) {
     return true;
   }
 
@@ -87,7 +90,7 @@ function isApproxEqual(x, y, opts) {
   var state = [];
 
   function loop(a, b, n) {
-    if (_.isNaN(a) && _.isNaN(b)) {
+    if (isNaN(a) && isNaN(b)) {
       return true;
     }
 


### PR DESCRIPTION
This resolves the missing module error when lodash isn't installed as a global or transient dependency.
```
❯ npm install jsverify && node -e 'require("jsverify")'

[...]

module.js:457
    throw err;
    ^

Error: Cannot find module 'lodash'
    at Function.Module._resolveFilename (module.js:455:15)
    at Function.Module._load (module.js:403:25)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/Scott/build/jsverify-scratch/node_modules/jsverify/lib/utils.js:4:9)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
```