### PR TITLE
Added 'options' field to 'jsc.property'

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ for now in either identity or promise functor, for synchronous and promise prope
 
     Same as `check`, but throw exception if property doesn't hold.
 
-- `property(name: string, ...)`
+- `property(name: string, opts: checkoptions?, ...)`
 
    Assuming there is globally defined `it`, the same as:
 
@@ -152,6 +152,11 @@ for now in either identity or promise functor, for synchronous and promise prope
    jsc.property("+0 === -0", function () {
      return +0 === -0;
    });
+   ```
+
+   The standard `checkopts` can be passed through:
+   ```js
+   jsc.property("(b && b) === b", {tests: 10}, jsc.bool, b => (b && b) === b);
    ```
 
 - `compile(desc: string, env: typeEnv?): arbitrary a`

--- a/lib/jsverify.js
+++ b/lib/jsverify.js
@@ -364,7 +364,7 @@ function checkThrow(property, opts) {
 }
 
 /**
-   - `property(name: string, ...)`
+   - `property(name: string, opts: checkoptions?, ...)`
 
       Assuming there is globally defined `it`, the same as:
 
@@ -380,10 +380,20 @@ function checkThrow(property, opts) {
         return +0 === -0;
       });
       ```
+
+      The standard `checkopts` can be passed through:
+      ```js
+      jsc.property("(b && b) === b", {tests: 10}, jsc.bool, b => (b && b) === b);
+      ```
 */
-function bddProperty(name) {
+function bddProperty(name, opts) {
   /* global it: true */
   var args = Array.prototype.slice.call(arguments, 1);
+  if (typeof opts === "object" && !opts.generator) {
+    args = args.slice(1);
+  } else {
+    opts = {};
+  }
   if (args.length === 1) {
     it(name, function () {
       return functor.run(functor.map(args[0](), function (result) { // eslint-disable-line consistent-return
@@ -397,7 +407,7 @@ function bddProperty(name) {
   } else {
     var prop = forall.apply(undefined, args);
     it(name, function () {
-      return checkThrow(prop);
+      return checkThrow(prop, opts);
     });
   }
   /* global it: false */

--- a/test/jsverify.js
+++ b/test/jsverify.js
@@ -25,5 +25,10 @@ describe("jsverify", function () {
 
       it = origIt;
     });
+
+    jsc.property("takes options", { size: 100, rngState: "000123456789abcdfe" }, jsc.nat(), function (n) {
+      return n < 100;
+    });
+
   });
 });


### PR DESCRIPTION
Hi,

I wanted to be able to pass the `checkoptions` array into `jsc.property()`, and apparently I'm not the only one, #151 was created years ago.

I figured I'd quickly implement this functionality, and wondered if it would be appreciated in the main branch.