### PR TITLE
Fixed typescript type definitions for either and sum

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -107,6 +107,7 @@ declare namespace JSVerify {
   const unit: Arbitrary<any>;
 
   function oneOf<T>(gs: Arbitrary<T>[]): Arbitrary<T>;
+  function record<T>(arbs: { [P in keyof T]: Arbitrary<T[P]> }): Arbitrary<T>;
 
 	/* tslint:disable:max-line-length */
   function forall<A, T>(arb1: Arbitrary<A>, prop: (t: A) => Property<T>): Property<T>;

--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -49,6 +49,16 @@ declare namespace JSVerify {
   type integerFn = (maxsize: number) => Arbitrary<number>;
   type integerFn2 = (minsize: number, maxsize: number) => Arbitrary<number>;
 
+  interface Either<T> {
+    value: T;
+  }
+
+  interface Addend<T> {
+    idx: number;
+    len: number;
+    value: T;
+  }
+
   const integer: Arbitrary<number> & integerFn & integerFn2;
   const nat: Arbitrary<number> & integerFn;
 	// tslint:disable-next-line:variable-name
@@ -78,11 +88,11 @@ declare namespace JSVerify {
 
   //Combinators
   function nonShrink<T>(arb: Arbitrary<T>): Arbitrary<T>;
-  function either<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<T | U>;
+  function either<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<Either<T | U>>;
   function pair<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<[T, U]>;
 
   function tuple(arbs: Arbitrary<any>[]): Arbitrary<any[]>;
-  function sum(arbs: Arbitrary<any>[]): Arbitrary<any>;
+  function sum<T>(arbs: Arbitrary<T>[]): Arbitrary<Addend<T>>;
 
   function dict<T>(arb: Arbitrary<T>): Arbitrary<{ [s: string]: T }>;
   function array<T>(arb: Arbitrary<T>): Arbitrary<T[]>;

--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -62,6 +62,8 @@ declare namespace JSVerify {
     fold<U>(f: (idx: number, len: number, value: T) => U): U;
   }
 
+  function addend<T>(idx: number, len: number, value: T): Addend<T>;
+
   const integer: Arbitrary<number> & integerFn & integerFn2;
   const nat: Arbitrary<number> & integerFn;
 	// tslint:disable-next-line:variable-name

--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -106,7 +106,7 @@ declare namespace JSVerify {
   const json: Arbitrary<any>;
   const unit: Arbitrary<any>;
 
-  function oneOf<T>(gs: Arbitrary<T>[]): Arbitrary<T>;
+  function oneof<T>(gs: Arbitrary<T>[]): Arbitrary<T>;
   function record<T>(arbs: { [P in keyof T]: Arbitrary<T[P]> }): Arbitrary<T>;
 
 	/* tslint:disable:max-line-length */
@@ -175,7 +175,7 @@ declare namespace JSVerify {
 
   interface GeneratorFunctions {
     constant<U>(u: U): Generator<U>;
-    oneOf<U>(gens: Generator<U>[]): Generator<U>;
+    oneof<U>(gens: Generator<U>[]): Generator<U>;
     recursive<U>(genZ: Generator<U>, f: (u: U) => U): Generator<U>;
     pair<T, U>(genA: Generator<T>, genB: Generator<U>): Generator<[T, U]>;
     either<T, U>(genA: Generator<T>, genB: Generator<U>): Generator<T | U>;

--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -49,14 +49,17 @@ declare namespace JSVerify {
   type integerFn = (maxsize: number) => Arbitrary<number>;
   type integerFn2 = (minsize: number, maxsize: number) => Arbitrary<number>;
 
-  interface Either<T> {
-    value: T;
+  interface Either<T, U> {
+    value: T | U;
+    either<V>(f: (x: T) => V, g: (x: U) => V): V;
   }
 
   interface Addend<T> {
     idx: number;
     len: number;
     value: T;
+
+    fold<U>(f: (idx: number, len: number, value: T) => U): U;
   }
 
   const integer: Arbitrary<number> & integerFn & integerFn2;
@@ -88,11 +91,12 @@ declare namespace JSVerify {
 
   //Combinators
   function nonShrink<T>(arb: Arbitrary<T>): Arbitrary<T>;
-  function either<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<Either<T | U>>;
+  function either<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<Either<T, U>>;
   function pair<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<[T, U]>;
 
   function tuple(arbs: Arbitrary<any>[]): Arbitrary<any[]>;
   function sum<T>(arbs: Arbitrary<T>[]): Arbitrary<Addend<T>>;
+  function sum(arbs: Arbitrary<any>[]): Arbitrary<Addend<any>>;
 
   function dict<T>(arb: Arbitrary<T>): Arbitrary<{ [s: string]: T }>;
   function array<T>(arb: Arbitrary<T>): Arbitrary<T[]>;

--- a/test-ts/addend.ts
+++ b/test-ts/addend.ts
@@ -1,0 +1,9 @@
+import * as jsc from "../lib/jsverify.js";
+
+const addend: jsc.Addend<string> = jsc.addend(1, 2, 'foo');
+
+const idx: number = addend.idx;
+const len: number = addend.len;
+const value: string = addend.value;
+
+const foldResult: boolean = addend.fold((idx: number, len: number, value: string) => true);

--- a/test-ts/either.ts
+++ b/test-ts/either.ts
@@ -1,0 +1,9 @@
+import * as jsc from "../lib/jsverify.js";
+
+const arbitrary: jsc.Arbitrary<jsc.Either<string, boolean>> = jsc.either(jsc.string, jsc.bool);
+
+const either: jsc.Either<string, boolean> = arbitrary.generator(1)
+
+const value: string | boolean = either.value;
+
+const foo: number = either.either((x: string) => 0, (x: boolean) => 1);

--- a/test-ts/oneof.ts
+++ b/test-ts/oneof.ts
@@ -1,0 +1,12 @@
+import * as jsc from "../lib/jsverify.js";
+
+
+const arbitrary: jsc.Arbitrary<number> = jsc.oneof([
+    jsc.constant(1),
+    jsc.constant(2)
+]);
+
+const generator: jsc.Generator<number> = jsc.generator.oneof([
+    jsc.generator.constant(1),
+    jsc.generator.constant(2),
+]);

--- a/test-ts/record.ts
+++ b/test-ts/record.ts
@@ -1,0 +1,11 @@
+import * as jsc from "../lib/jsverify.js";
+
+interface Record {
+    string: string;
+    boolean: boolean;
+};
+
+const arbitrary: jsc.Arbitrary<Record> = jsc.record({
+    string: jsc.string,
+    boolean: jsc.bool
+});

--- a/test-ts/sum.ts
+++ b/test-ts/sum.ts
@@ -1,0 +1,11 @@
+import * as jsc from "../lib/jsverify.js";
+
+const arbitrary1: jsc.Arbitrary<jsc.Addend<'foo' | boolean>> = jsc.sum([
+    jsc.constant<'foo' | boolean>('foo'),
+    jsc.constant<'foo' | boolean>(true)
+]);
+
+const arbitrary2: jsc.Arbitrary<any> = jsc.sum([
+    jsc.constant('foo'),
+    jsc.constant(true)
+]);


### PR DESCRIPTION
The typescript definition file for either and sum were incorrect, because the generated values are wrapped inside objects (Left/Right and Addend).

I also made sum take a type parameter rather than using `any`, because it seems like in most cases you would want this to be the union of all the types of the elements in the `arbs` array, which is what TypeScript would infer this parameter to be.