### PR TITLE
Added type definitions for jsc.record

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -93,6 +93,7 @@ declare namespace JSVerify {
   const unit: Arbitrary<any>;
 
   function oneOf<T>(gs: Arbitrary<T>[]): Arbitrary<T>;
+  function record<T>(arbs: { [P in keyof T]: Arbitrary<T[P]> }): Arbitrary<T>;
 
 	/* tslint:disable:max-line-length */
   function forall<A, T>(arb1: Arbitrary<A>, prop: (t: A) => Property<T>): Property<T>;

--- a/test-ts/record.ts
+++ b/test-ts/record.ts
@@ -1,0 +1,11 @@
+import * as jsc from "../lib/jsverify.js";
+
+interface Record {
+    string: string;
+    boolean: boolean;
+};
+
+const arbitrary: jsc.Arbitrary<Record> = jsc.record({
+    string: jsc.string,
+    boolean: jsc.bool
+});


### PR DESCRIPTION
I've added tests which pass by being typechecked. This seems to be how it's done in DefinitelyTyped.