### PR TITLE
Fail suchthat generator when failing to create good value

### DIFF
--- a/lib/suchthat.js
+++ b/lib/suchthat.js
@@ -26,7 +26,11 @@ function suchthat(arb, userenv, predicate) {
 
   return arbitraryBless({
     generator: generator.bless(function (size) {
+      var failedAttempts = 0;
       for (var i = 0; ; i++) {
+        if (failedAttempts >= 1000) {
+          throw new Error("Too many attempts trying to generate a value.");
+        }
         // if 5 tries failed, increase size
         if (i > 5) {
           i = 0;
@@ -36,6 +40,8 @@ function suchthat(arb, userenv, predicate) {
         var x = arb.generator(size);
         if (predicate(x)) {
           return x;
+        } else {
+          failedAttempts += 1;
         }
       }
     }),

--- a/test/suchthat.js
+++ b/test/suchthat.js
@@ -4,6 +4,7 @@
 
 var jsc = require("../lib/jsverify.js");
 var arbitraryAssert = require("../lib/arbitraryAssert.js");
+var expect = require("chai").expect;
 
 describe("suchthat", function () {
   var arb = jsc.suchthat(jsc.integer, function (v) {
@@ -27,5 +28,19 @@ describe("suchthat", function () {
     jsc.assert(jsc.forall(arbAsString, function (value) {
       return parseInt(value, 10) % 2 === 0;
     }));
+  });
+
+  it("should fail after too many attempts at generating a value", function () {
+    var degenerateArb = jsc.suchthat(jsc.nat, function () {
+      return false;
+    });
+
+    try {
+      jsc.assert(jsc.forall(degenerateArb, function () {
+        return true;
+      }));
+    } catch (e) {
+      expect(e.message).to.equal("Too many attempts trying to generate a value.");
+    }
   });
 });


### PR DESCRIPTION
The current implementation of `suchthat` will run indefinitely when a predicate is failing to match values created by the underlying generator.

This PR puts an upper bound on the number of failed attempts (1000).