### PR TITLE
Fix misleading warning about 'oneof'

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The DSL is based on a subset of language recognized by [typify-parser](https://g
 - *functions* are supported: `"bool -> bool"` is evaluated to `jsc.fn(jsc.bool)`.
 - *square brackets* are treated as a shorthand for the array type: `"[nat]"` is evaluated to `jsc.array(jsc.nat)`.
 - *union*: `"bool | nat"` is evaluated to `jsc.sum([jsc.bool, jsc.nat])`.
-    - **Note** `oneof` cannot be shrinked, because the union is untagged, we don't know which shrink to use.
+    - **Note** `sum` cannot be shrinked, because the union is untagged, we don't know which shrink to use.
 - *conjunction*: `"bool & nat"` is evaluated to `jsc.tuple(jsc.bool, jsc.nat)`.
 - *anonymous records*: `"{ b: bool; n: nat }"` is evaluated to `jsc.record({ b: jsc.bool, n: jsc.nat })`.
 - *EXPERIMENTAL: recursive types*: `"rec list -> unit | (nat & list)"`.


### PR DESCRIPTION
I believe that this warning should not reference `oneof`, but `sum`?