### PR TITLE
Corrected typo in TS type definition

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -77,7 +77,7 @@ declare namespace JSVerify {
   const asciinestring: Arbitrary<string>;
 
   //Combinators
-  function nonShrink<T>(arb: Arbitrary<T>): Arbitrary<T>;
+  function nonshrink<T>(arb: Arbitrary<T>): Arbitrary<T>;
   function either<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<T | U>;
   function pair<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<[T, U]>;
 


### PR DESCRIPTION
changed nonShrink to nonshrink
related to: https://github.com/jsverify/jsverify/issues/233