### PR TITLE
Make type of bless more precise in jsverify.d.ts

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -3,8 +3,8 @@ declare namespace JSVerify {
 
   interface ArbitraryLike<T> {
     generator: Generator<T>;
-    show: Show<T>;
-    shrink: Shrink<T>;
+    show?: Show<T>;
+    shrink?: Shrink<T>;
   }
 
   interface ArbitraryFns<T> {


### PR DESCRIPTION
The `show` and `shrink` arguments to `bless` are actually optional.