### PR TITLE
`throws` additionaly accepts a regular expression as it's message argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ for now in either identity or promise functor, for synchronous and promise prope
     [-0.4199344692751765, false]
     ```
 
-- `throws(block: () -> a, error: class?, message: string?): bool`
+- `throws(block: () -> a, error: class?, message: string? | regex?): bool`
 
   Executes nullary function `block`. Returns `true` if `block` throws. See [assert.throws](https://nodejs.org/api/assert.html#assert_assert_throws_block_error_message)
 

--- a/lib/jsverify.js
+++ b/lib/jsverify.js
@@ -450,13 +450,18 @@ function sampler(arb, size) {
 }
 
 /**
-  - `throws(block: () -> a, error: class?, message: string?): bool`
+  - `throws(block: () -> a, error: class?, message: string? | regex?): bool`
 
     Executes nullary function `block`. Returns `true` if `block` throws. See [assert.throws](https://nodejs.org/api/assert.html#assert_assert_throws_block_error_message)
 */
 function throws(block, error, message) {
   assert(error === undefined || typeof error === "function", "throws: error parameter must be a constructor");
-  assert(message === undefined || typeof message === "string", "throws: message parameter must be a string");
+  assert(
+    message === undefined ||
+      typeof message === "string" ||
+      message instanceof RegExp,
+    "throws: message parameter must be a string or regular expression"
+  );
 
   try {
     block();
@@ -464,7 +469,11 @@ function throws(block, error, message) {
   } catch (e) {
     if (error !== undefined) {
       if (e instanceof error) {
-        return message === undefined || e.message === message;
+        if (message instanceof RegExp) {
+          return message.test(e.message);
+        } else {
+          return message === undefined || e.message === message;
+        }
       } else {
         return false;
       }

--- a/test/throws.js
+++ b/test/throws.js
@@ -28,4 +28,16 @@ describe("throws", function () {
 
     return jsc.throws(block, Error, msg) === b;
   });
+
+  jsc.property("regex", "bool", "string", function (b, msg) {
+    var block = function () {
+      throw (b ? new Error(msg) : "other-error");
+    };
+
+    return jsc.throws(
+      block,
+      Error,
+      new RegExp(msg.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&"))
+    ) === b;
+  });
 });


### PR DESCRIPTION
In my use case testing exception messages for exact match is cumbersome, since the messages can be multiple lines long and contain variable parts. With this patch I can do a patch in `jsc.throws` based on a regular expression.

    jsc.throws(block, TypeError, /my message/)

Please let me know if I was missing something.