### PR TITLE
Remove outdated Jasmine reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Erroneous case is found with first try.
 
 ### Usage with [jasmine](https://jasmine.github.io/)
 
-Check [jasmineHelpers.js](helpers/jasmineHelpers.js) and [jasmineHelpers2.js](helpers/jasmineHelpers2.js) for jasmine 1.3 and 2.0 respectively.
+Check [jasmineHelpers2.js](helpers/jasmineHelpers2.js) for jasmine 2.0.
 
 ## API Reference
 

--- a/lib/jsverify.js
+++ b/lib/jsverify.js
@@ -81,7 +81,7 @@
 
   ### Usage with [jasmine](https://jasmine.github.io/)
 
-  Check [jasmineHelpers.js](helpers/jasmineHelpers.js) and [jasmineHelpers2.js](helpers/jasmineHelpers2.js) for jasmine 1.3 and 2.0 respectively.
+  Check [jasmineHelpers2.js](helpers/jasmineHelpers2.js) for jasmine 2.0.
 
   ## API Reference
 


### PR DESCRIPTION
Remove the link to a removed helper function. PR #245 removed the Jasmine 1 helper, but left the reference to the helper in the readme/docs.

I haven't regenerated the readme as part of this PR, but it's easy to do - just didn't know if that was part of a maintenance/deployment step for this project. Please let me know and I can make it happen!