### PR TITLE
Added overloads to typescript definitions for jsc.tuple.

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -81,7 +81,13 @@ declare namespace JSVerify {
   function either<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<T | U>;
   function pair<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<[T, U]>;
 
+  function tuple<A>(arbs: [Arbitrary<A>]): Arbitrary<[A]>;
+  function tuple<A, B>(arbs: [Arbitrary<A>, Arbitrary<B>]): Arbitrary<[A, B]>;
+  function tuple<A, B, C>(arbs: [Arbitrary<A>, Arbitrary<B>, Arbitrary<C>]): Arbitrary<[A, B, C]>;
+  function tuple<A, B, C, D>(arbs: [Arbitrary<A>, Arbitrary<B>, Arbitrary<C>, Arbitrary<D>]): Arbitrary<[A, B, C, D]>;
+  function tuple<A, B, C, D, E>(arbs: [Arbitrary<A>, Arbitrary<B>, Arbitrary<C>, Arbitrary<D>, Arbitrary<E>]): Arbitrary<[A, B, C, D, E]>;
   function tuple(arbs: Arbitrary<any>[]): Arbitrary<any[]>;
+
   function sum(arbs: Arbitrary<any>[]): Arbitrary<any>;
 
   function dict<T>(arb: Arbitrary<T>): Arbitrary<{ [s: string]: T }>;

--- a/test-ts/tuple.ts
+++ b/test-ts/tuple.ts
@@ -1,0 +1,41 @@
+import * as jsc from "../lib/jsverify.js";
+
+const arbitrary1: jsc.Arbitrary<[number]> = jsc.tuple([
+    jsc.integer,
+]);
+
+const arbitrary2: jsc.Arbitrary<[number, string]> = jsc.tuple([
+    jsc.integer,
+    jsc.string,
+]);
+
+const arbitrary3: jsc.Arbitrary<[number, string, boolean]> = jsc.tuple([
+    jsc.integer,
+    jsc.string,
+    jsc.bool,
+]);
+
+const arbitrary4: jsc.Arbitrary<[number, string, boolean, number]> = jsc.tuple([
+    jsc.integer,
+    jsc.string,
+    jsc.bool,
+    jsc.integer,
+]);
+
+const arbitrary5: jsc.Arbitrary<[number, string, boolean, number, string]> = jsc.tuple([
+    jsc.integer,
+    jsc.string,
+    jsc.bool,
+    jsc.integer,
+    jsc.string,
+]);
+
+// Falls back to any[] if no overloads are available.
+const arbitrary6: jsc.Arbitrary<any[]> = jsc.tuple([
+    jsc.integer,
+    jsc.string,
+    jsc.bool,
+    jsc.integer,
+    jsc.string,
+    jsc.bool,
+]);


### PR DESCRIPTION
This follows the ordinary pattern of specifying `n` overloads for when you need a function to take a variable number of type parameters.