### PR TITLE
Added overloads to typescript definitions of oneof.

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -92,6 +92,10 @@ declare namespace JSVerify {
   const json: Arbitrary<any>;
   const unit: Arbitrary<any>;
 
+  function oneof<A, B>(gs: [Arbitrary<A>, Arbitrary<B>]): Arbitrary<A | B>;
+  function oneof<A, B, C>(gs: [Arbitrary<A>, Arbitrary<B>, Arbitrary<C>]): Arbitrary<A | B | C>;
+  function oneof<A, B, C, D>(gs: [Arbitrary<A>, Arbitrary<B>, Arbitrary<C>, Arbitrary<D>]): Arbitrary<A | B | C | D>;
+  function oneof<A, B, C, D, E>(gs: [Arbitrary<A>, Arbitrary<B>, Arbitrary<C>, Arbitrary<D>, Arbitrary<E>]): Arbitrary<A | B | C | D | E>;
   function oneof<T>(gs: Arbitrary<T>[]): Arbitrary<T>;
   function record<T>(arbs: { [P in keyof T]: Arbitrary<T[P]> }): Arbitrary<T>;
 

--- a/test-ts/oneof.ts
+++ b/test-ts/oneof.ts
@@ -1,12 +1,42 @@
-import * as jsc from "../lib/jsverify.js";
-
+import * as jsc from '../lib/jsverify.js';
 
 const arbitrary: jsc.Arbitrary<number> = jsc.oneof([
     jsc.constant(1),
-    jsc.constant(2)
+    jsc.constant(2),
 ]);
 
 const generator: jsc.Generator<number> = jsc.generator.oneof([
     jsc.generator.constant(1),
     jsc.generator.constant(2),
+]);
+
+const differentTypes1: jsc.Arbitrary<boolean> = jsc.oneof([
+    jsc.bool,
+]);
+
+const differentTypes2: jsc.Arbitrary<boolean | number> = jsc.oneof([
+    jsc.bool,
+    jsc.number,
+]);
+
+const differentTypes3: jsc.Arbitrary<boolean | number | string> = jsc.oneof([
+    jsc.bool,
+    jsc.number,
+    jsc.string,
+]);
+
+const differentTypes4: jsc.Arbitrary<boolean | number | string | { foo: boolean }> = jsc.oneof([
+    jsc.bool,
+    jsc.number,
+    jsc.string,
+    jsc.record({ foo: jsc.bool }),
+]);
+
+// tslint:disable-next-line:max-line-length
+const differentTypes5: jsc.Arbitrary<boolean | number | string | { foo: boolean } | { bar: number }> = jsc.oneof([
+    jsc.bool,
+    jsc.number,
+    jsc.string,
+    jsc.record({ foo: jsc.bool }),
+    jsc.record({ bar: jsc.number }),
 ]);


### PR DESCRIPTION
When the elements in the array argument to oneof are of different types, TypeScript sometimes has trouble inferring the common subtype between them. This PR fixes this by defining a bunch of tuple overloads for oneof.