### PR TITLE
ts typings: sampler, optional sampleSize

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -12,7 +12,7 @@ declare namespace JSVerify {
   }
 
   function bless<U>(arb: ArbitraryLike<U>): Arbitrary<U>;
-  function sampler<U>(arb: Arbitrary<U>, genSize?: number): (sampleSize: number) => U;
+  function sampler<U>(arb: Arbitrary<U>, genSize?: number): (sampleSize?: number) => U;
   function small<U>(arb: Arbitrary<U>): Arbitrary<U>;
   function suchthat<U>(arb: Arbitrary<U>, predicate: (u: U) => boolean): Arbitrary<U>;
 


### PR DESCRIPTION
`sampleSize` is actually optional (see https://github.com/jsverify/jsverify/blob/0d392dd58008d0a7df2c36f3a0ff44e23e3f11e8/lib/jsverify.js#L446), not mandatory as declared by the types.