### PR TITLE
Fixed TypeScript bindings for either.

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -46,6 +46,16 @@ declare namespace JSVerify {
 
   type Show<T> = (t: T) => string;
   type Property<T> = boolean | void | T;
+
+  interface Either<T, U> {
+    value: T | U;
+    either<X>(l: (a: T) => X, r: (b: U) => X): X;
+    isEqual(other: Either<T, U>): boolean;
+    bimap<X, Y>(f: (a: T) => X, g: (b: U) => Y): Either<X, Y>;
+    first<X>(f: (a: T) => X): Either<X, U>;
+    second<Y>(g: (b: U) => Y): Either<T, Y>;
+  }
+
   type integerFn = (maxsize: number) => Arbitrary<number>;
   type integerFn2 = (minsize: number, maxsize: number) => Arbitrary<number>;
 
@@ -78,7 +88,7 @@ declare namespace JSVerify {
 
   //Combinators
   function nonshrink<T>(arb: Arbitrary<T>): Arbitrary<T>;
-  function either<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<T | U>;
+  function either<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<Either<T,U>>;
   function pair<T, U>(arbA: Arbitrary<T>, arbB: Arbitrary<U>): Arbitrary<[T, U]>;
 
   function tuple<A>(arbs: [Arbitrary<A>]): Arbitrary<[A]>;
@@ -174,7 +184,7 @@ declare namespace JSVerify {
     oneof<U>(gens: Generator<U>[]): Generator<U>;
     recursive<U>(genZ: Generator<U>, f: (u: U) => U): Generator<U>;
     pair<T, U>(genA: Generator<T>, genB: Generator<U>): Generator<[T, U]>;
-    either<T, U>(genA: Generator<T>, genB: Generator<U>): Generator<T | U>;
+    either<T, U>(genA: Generator<T>, genB: Generator<U>): Generator<Either<T, U>>;
 
     tuple(gens: Generator<any>[]): Generator<any[]>;
     sum(gens: Generator<any>[]): Generator<any>;
@@ -206,7 +216,7 @@ declare namespace JSVerify {
   interface ShrinkFunctions {
     noop: Shrink<any>;
     pair<T, U>(shrA: Shrink<T>, shrB: Shrink<U>): Shrink<[T, U]>;
-    either<T, U>(shrA: Shrink<T>, shrB: Shrink<U>): Shrink<T | U>;
+    either<T, U>(shrA: Shrink<T>, shrB: Shrink<U>): Shrink<Either<T, U>>;
 
     tuple(shrs: Shrink<any>[]): Shrink<any[]>;
     sum(shrs: Shrink<any>[]): Shrink<any>;
@@ -220,7 +230,7 @@ declare namespace JSVerify {
   interface ShowFunctions {
     def<T>(x: T): string;
     pair<T, U>(sA: Show<T>, sB: Show<U>, x: [T, U]): string;
-    either<T, U>(sA: Show<T>, sB: Show<U>, x: (T | U)): string;
+    either<T, U>(sA: Show<T>, sB: Show<U>, x: Either<T, U>): string;
 
     tuple(shs: Show<any>[], x: any[]): string;
     sum(shs: Show<any>[], x: any): string;

--- a/test-ts/either.ts
+++ b/test-ts/either.ts
@@ -1,0 +1,32 @@
+import * as jsc from '../lib/jsverify.js';
+
+const arb1: jsc.Arbitrary<jsc.Either<number, string>> =
+  jsc.either(jsc.number, jsc.string);
+
+const gen1: jsc.Generator<jsc.Either<string, Date>> =
+  jsc.generator.either(
+    jsc.generator.constant('testing either'),
+    jsc.generator.constant(new Date()),
+  );
+
+const shrink1: jsc.Shrink<jsc.Either<boolean, RegExp>> =
+  jsc.shrink.either(
+    jsc.shrink.bless((x: boolean) => [ x ]),
+    jsc.shrink.bless((x: RegExp) => [ x ]),
+  );
+
+const show1: string =
+  jsc.show.either(
+    x => x.toUpperCase(),
+    y => y.toDateString(),
+    gen1(1)
+  );
+
+const either1: jsc.Either<string, Date> = gen1(1);
+const value1: string | Date = either1.value;
+
+const either2: string = either1.either(x => x.toUpperCase(), y => y.toDateString());
+const bool1: boolean = either1.isEqual(gen1(1));
+const bimap1: jsc.Either<number, boolean> = either1.bimap(a => 4, b => true);
+const first1: jsc.Either<RegExp, Date> = either1.first(a => /test/);
+const second1: jsc.Either<string, Error> = either1.second(a => new Error('test'));


### PR DESCRIPTION
Fixes issue #242.

- Introduced an Either interface with a `value: T | U` property and the other Either methods.
- Changed the return type of either for Arbitrary, Generator, Shrink and Show to be Either<T, U> instead of T | U.
- Added compile-time tests to test obtaining and using an Either in TypeScript.