### PR TITLE
Fix typings for recursive

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -182,7 +182,7 @@ declare namespace JSVerify {
   interface GeneratorFunctions {
     constant<U>(u: U): Generator<U>;
     oneof<U>(gens: Generator<U>[]): Generator<U>;
-    recursive<U>(genZ: Generator<U>, f: (u: U) => U): Generator<U>;
+    recursive<U>(genZ: Generator<U>, f: (u: Generator<U>) => Generator<U>): Generator<U>;
     pair<T, U>(genA: Generator<T>, genB: Generator<U>): Generator<[T, U]>;
     either<T, U>(genA: Generator<T>, genB: Generator<U>): Generator<Either<T, U>>;
 


### PR DESCRIPTION
Fixed wrong type for the second argument in `recursive`.