### PR TITLE
Update bless example to include generator bless

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ The DSL is based on a subset of language recognized by [typify-parser](https://g
 
   ```js
   var arbTokens = jsc.bless({
-    generator: function () {
+    generator: jsc.generator.bless(function () {
       switch (jsc.random(0, 2)) {
         case 0: return "foo";
         case 1: return "bar";
         case 2: return "quux";
-      }
+      })
     }
   });
   ```


### PR DESCRIPTION
I ran into a type error when following the example for bless - realized I need to use `generator.bless` on the generator function to get the types to match up.