### PR TITLE
Samplers can return U | U[]

### DIFF
--- a/lib/jsverify.d.ts
+++ b/lib/jsverify.d.ts
@@ -12,7 +12,7 @@ declare namespace JSVerify {
   }
 
   function bless<U>(arb: ArbitraryLike<U>): Arbitrary<U>;
-  function sampler<U>(arb: Arbitrary<U>, genSize?: number): (sampleSize: number) => U;
+  function sampler<U>(arb: Arbitrary<U>, genSize?: number): (sampleSize: number) => U | U[];
   function small<U>(arb: Arbitrary<U>): Arbitrary<U>;
   function suchthat<U>(arb: Arbitrary<U>, predicate: (u: U) => boolean): Arbitrary<U>;
 


### PR DESCRIPTION
Sampler can return an array of U when sample size is a number.

Evidence here: https://github.com/jsverify/jsverify/blob/6e0b0ba705936b6f74a0df4a6ef043e2491b85a9/lib/jsverify.js#L445