### PR TITLE
Add Jest helper and support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BINDIR=node_modules/.bin
 JSHINT=$(BINDIR)/jshint
 ESLINT=$(BINDIR)/eslint
 JSCS=$(BINDIR)/jscs
+JEST=$(BINDIR)/jest
 TSLINT=$(BINDIR)/tslint
 MOCHA=$(BINDIR)/mocha
 IMOCHA=$(BINDIR)/_mocha
@@ -22,7 +23,7 @@ all : test
 test :
 	if [ "x${TRAVIS}" = "xtrue" ]; then $(MAKE) test-travis; else $(MAKE) test-default; fi
 
-test-default : jshint eslint jscs mocha istanbul mocha-ts david npm-freeze
+test-default : jshint eslint jscs jest mocha istanbul mocha-ts david npm-freeze
 
 test-travis : test-readme test-default
 
@@ -49,6 +50,9 @@ karma : tests-bundle.js
 
 jasmine : $(DIST)
 	$(KARMA) start karma.jasmine.conf.js
+
+jest :
+	$(JEST) helpers
 
 mocha :
 	$(MOCHA) --reporter spec test

--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ jsc.assert(boolFnAppliedThrice);
 
 ## Documentation
 
+### Usage with [Jest](https://jestjs.io)
+
+Using jsverify with Jest is very easy, you can either use `jsc.property` out of the box:
+
+```js
+describe("sort", function () {
+  jsc.property("(b && b) === b", jsc.bool, b => (b && b) === b);
+});
+```
+
+Or you can choose to use the helper, which exports an `itHolds` helper function. And you can use it like this:
+
+```js
+describe("a simple jest test suite", function () {
+  itHolds("(b && b) === b", jsc.bool, function (b) {
+    expect(b && b).toBe(b);
+  });
+});
+```
+
 ### Usage with [mocha](http://mochajs.org/)
 
 Using jsverify with mocha is easy, just define the properties and use `jsverify.assert`.

--- a/helpers/jestHelper.js
+++ b/helpers/jestHelper.js
@@ -1,0 +1,27 @@
+/* global it: true */
+/* eslint strict:[2,"function"] */
+var jsc = require("jsverify");
+
+/**
+ * wrapper function for using jsverify with jest syntax
+ *
+ * @param description string describing the test
+ * @param arbitrary a jsverify record (or other arbitrary)
+ * @param testFn function that expects, in proper jest syntax
+ * @param opts options for jsverify
+ */
+function itHolds(description, arbitrary, testFn, options) {
+  "use strict";
+
+  it(description, function () {
+    jsc.assert(
+      jsc.forall(arbitrary, function (val) {
+        testFn(val);
+        return true;
+      }),
+      options
+    );
+  });
+}
+
+module.exports = { itHolds: itHolds };

--- a/helpers/jestHelper.test.js
+++ b/helpers/jestHelper.test.js
@@ -1,0 +1,13 @@
+/* global describe:true, expect:true */
+/* eslint strict:[2,"function"] */
+
+var jsc = require("jsverify");
+var itHolds = require("./jestHelper").itHolds;
+
+describe("a simple jsverify test", function () {
+  "use strict";
+
+  itHolds("(b && b) === b", jsc.bool, function (b) {
+    expect(b && b).toBe(b);
+  });
+});

--- a/lib/jsverify.js
+++ b/lib/jsverify.js
@@ -36,6 +36,26 @@
 /**
   ## Documentation
 
+  ### Usage with [Jest](https://jestjs.io)
+
+  Using jsverify with Jest is very easy, you can either use `jsc.property` out of the box:
+
+  ```js
+  describe("sort", function () {
+    jsc.property("(b && b) === b", jsc.bool, b => (b && b) === b);
+  });
+  ```
+
+  Or you can choose to use the helper, which exports an `itHolds` helper function. And you can use it like this:
+
+  ```js
+  describe("a simple jest test suite", function () {
+    itHolds("(b && b) === b", jsc.bool, function (b) {
+      expect(b && b).toBe(b);
+    });
+  });
+  ```
+
   ### Usage with [mocha](http://mochajs.org/)
 
   Using jsverify with mocha is easy, just define the properties and use `jsverify.assert`.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "esprima": "^4.0.0",
     "istanbul": "^0.4.1",
     "jasmine-core": "^3.1.0",
+    "jest": "^24.0.0",
     "jscs": "^3.0.7",
     "jshint": "^2.7.0",
     "karma": "^4.0.0",


### PR DESCRIPTION
This PR fixes #289 and fixes #281.

In this PR, I've taken a first stab at adding support for Jest. The reasons for this is discussed in #289. This PR is heavily inspired by @JayAndCatchFire and the work shown in #281.

So far, I have done the following:

- Add the helper function created by @JayAndCatchFire
- Add a simple test co-located with the helper file
- Add Jest to the testing pipeline in the Makefile
- Add documentation to describe how to use the helper

I have run `make test` and `make literate`, and both commands yield the expected results.

However, I'm not sure how users will be requiring the helper and I'm not sure how to push the helper into the build pipeline. It would be good to get some guidance on this, perhaps @phadej can provide some guidance?

Thanks for your time :)