### PR TITLE
Set lib options to lowercase in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "lib": ["DOM", "ES6"]
+    "lib": ["dom", "es6"]
   }
 }


### PR DESCRIPTION
These values need to be lowercase according to the error messages coming from VSCode's typescript module.