### PR TITLE
Fix JSCheck hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ likely easy to write, even *complete* inverse doesn't exist.
 
 ### JavaScript
 
-- [JSCheck](http://www.jscheck.org/)
+- [JSCheck](https://www.crockford.com/jscheck.html)
 - [claire](https://npmjs.org/package/claire)
 - [gent](https://npmjs.org/package/gent)
 - [fatcheck](https://npmjs.org/package/fatcheck)

--- a/related-work.md
+++ b/related-work.md
@@ -2,7 +2,7 @@
 
 ### JavaScript
 
-- [JSCheck](http://www.jscheck.org/)
+- [JSCheck](https://www.crockford.com/jscheck.html)
 - [claire](https://npmjs.org/package/claire)
 - [gent](https://npmjs.org/package/gent)
 - [fatcheck](https://npmjs.org/package/fatcheck)


### PR DESCRIPTION
This PR fixes the hyperlink for JSCheck (the URL in the README no longer points to the JSCheck documentation).

Douglas Crockford updated the hyperlink in the JSCheck repo in [this commit](https://github.com/douglascrockford/JSCheck/commit/13e41496ea4ccc5f0f2525b9692b063901669a8b).